### PR TITLE
changed mupen64plus video plugin from Glide64 to Glide64mk2

### DIFF
--- a/emu-cfgs/ps3_blu_controller/mupen64plus/mupen64plus.cfg
+++ b/emu-cfgs/ps3_blu_controller/mupen64plus/mupen64plus.cfg
@@ -306,7 +306,7 @@ Version = 1
 # Directory in which to search for plugins
 PluginDir = "/usr/lib/x86_64-linux-gnu/mupen64plus"
 # Filename of video plugin
-VideoPlugin = "mupen64plus-video-glide64.so"
+VideoPlugin = "mupen64plus-video-glide64mk2.so"
 # Filename of audio plugin
 AudioPlugin = "mupen64plus-audio-sdl.so"
 # Filename of input plugin

--- a/emu-cfgs/ps3_usb_controller/mupen64plus/mupen64plus.cfg
+++ b/emu-cfgs/ps3_usb_controller/mupen64plus/mupen64plus.cfg
@@ -306,7 +306,7 @@ Version = 1
 # Directory in which to search for plugins
 PluginDir = "/usr/lib/x86_64-linux-gnu/mupen64plus"
 # Filename of video plugin
-VideoPlugin = "mupen64plus-video-glide64.so"
+VideoPlugin = "mupen64plus-video-glide64mk2.so"
 # Filename of audio plugin
 AudioPlugin = "mupen64plus-audio-sdl.so"
 # Filename of input plugin

--- a/emu-cfgs/x360_usb_controller/mupen64plus/mupen64plus.cfg
+++ b/emu-cfgs/x360_usb_controller/mupen64plus/mupen64plus.cfg
@@ -306,7 +306,7 @@ Version = 1
 # Directory in which to search for plugins
 PluginDir = "/usr/lib/x86_64-linux-gnu/mupen64plus"
 # Filename of video plugin
-VideoPlugin = "mupen64plus-video-glide64.so"
+VideoPlugin = "mupen64plus-video-glide64mk2.so"
 # Filename of audio plugin
 AudioPlugin = "mupen64plus-audio-sdl.so"
 # Filename of input plugin

--- a/emu-cfgs/x360_wireless_controller/mupen64plus/mupen64plus.cfg
+++ b/emu-cfgs/x360_wireless_controller/mupen64plus/mupen64plus.cfg
@@ -306,7 +306,7 @@ Version = 1
 # Directory in which to search for plugins
 PluginDir = "/usr/lib/x86_64-linux-gnu/mupen64plus"
 # Filename of video plugin
-VideoPlugin = "mupen64plus-video-glide64.so"
+VideoPlugin = "mupen64plus-video-glide64mk2.so"
 # Filename of audio plugin
 AudioPlugin = "mupen64plus-audio-sdl.so"
 # Filename of input plugin


### PR DESCRIPTION
Glide64mk2 is the only plugin that correctly supports all testing ROMS, especially those from N64.tar.gz in the box-box. I haven't tried z64, though.

These are all the DLLs that currently get installed for mupen64plus: http://slexy.org/view/s20fNBO051
