### PR TITLE
change dolphin's sound driver from ALSA to pulseaudio

### DIFF
--- a/emu-cfgs/ps3_blu_controller/Dolphin/Dolphin.ini
+++ b/emu-cfgs/ps3_blu_controller/Dolphin/Dolphin.ini
@@ -219,7 +219,7 @@ Author =
 [DSP]
 EnableJIT = True
 DumpAudio = False
-Backend = ALSA
+Backend = Pulse
 Volume = 100
 CaptureLog = False
 [Input]

--- a/emu-cfgs/ps3_usb_controller/Dolphin/Dolphin.ini
+++ b/emu-cfgs/ps3_usb_controller/Dolphin/Dolphin.ini
@@ -219,7 +219,7 @@ Author =
 [DSP]
 EnableJIT = True
 DumpAudio = False
-Backend = ALSA
+Backend = Pulse
 Volume = 100
 CaptureLog = False
 [Input]

--- a/emu-cfgs/x360_usb_controller/Dolphin/Dolphin.ini
+++ b/emu-cfgs/x360_usb_controller/Dolphin/Dolphin.ini
@@ -219,7 +219,7 @@ Author =
 [DSP]
 EnableJIT = True
 DumpAudio = False
-Backend = ALSA
+Backend = Pulse
 Volume = 100
 CaptureLog = False
 [Input]

--- a/emu-cfgs/x360_wireless_controller/Dolphin/Dolphin.ini
+++ b/emu-cfgs/x360_wireless_controller/Dolphin/Dolphin.ini
@@ -219,7 +219,7 @@ Author =
 [DSP]
 EnableJIT = True
 DumpAudio = False
-Backend = ALSA
+Backend = Pulse
 Volume = 100
 CaptureLog = False
 [Input]


### PR DESCRIPTION
This should solve #80 "Sound driver sometimes crashes when usign load/save state (Dolphin)".

Good job on the installation of _dolphin-emu=4.0git-0ubuntu1~filthypants1_. Much better performance! (#112)
