### PR TITLE
changed installation source for GensGS form Librgeek to PPA

### DIFF
--- a/scriptmodules/emulators.shinc
+++ b/scriptmodules/emulators.shinc
@@ -203,14 +203,16 @@ function em_install_gens()
 	apt-get remove -y gens
 
 	echo "Installing Gens Sega CD/32X emulator"
-	wget --tries=50 -P /tmp "http://www.libregeek.org/RetroRig/Ubuntu-Trusty/emulators/gens//Gens_2.16.7_i386.deb"
-        dpkg -i "/tmp/Gens_2.16.7_i386.deb"
+	apt-get -y install gens
 
+        # deprecated: installation from libregeek.org:
+	#wget --tries=50 -P /tmp "http://www.libregeek.org/RetroRig/Ubuntu-Trusty/emulators/gens//Gens_2.16.7_i386.deb"
+        #dpkg -i "/tmp/Gens_2.16.7_i386.deb"
 	# cleanup pkg file
-	rm -f "/tmp/Gens_2.16.7_i386.deb"
+	#rm -f "/tmp/Gens_2.16.7_i386.deb"
 
 	# hold package after install against upgrades
-	apt-mark hold mednafen
+	apt-mark hold gens
 
 }
 


### PR DESCRIPTION
I forgot yesterday to change the gens installation to the PPA. I tried to update and install gens manually from the PPA, and tested it afterwards, looks OK.

Just FYI, directly after my chat with some launchpad guys on Wednesday, I managed to get gens compile on the PPAs server farm, but only for Lucid Lynx. After Lucid repositories can't by seen on Trusty, it couldn't be installed or upgraded automatically by `apt-get`.

However, the two patches _configure.patch_ and _gens_window_callbacks.cpp.patch_
(see https://github.com/ProfessorKaos64/RetroRig/tree/Ubuntu-14.04-Beta/supplemental/gens) from yesterday allow gens to compile under recent Linux distributions. _Configure_ now allows to compile with deprecated GTK+ macros, while I deleted drag & drop support in _gens_window_callbacks.cpp_.

This PR is related to #117 .
